### PR TITLE
Logic for propogating losers to their next round using rounds.lost_next_round_id field

### DIFF
--- a/src/components/round/EndRoundButton/EndRoundButton.tsx
+++ b/src/components/round/EndRoundButton/EndRoundButton.tsx
@@ -3,19 +3,21 @@ import { useState } from "react";
 import { GrChapterNext } from "react-icons/gr";
 
 import { toaster } from "../../ui/toaster";
+import handleEndRound from "../../../handlers/round/handleEndRound";
 
 import type { Round } from "../../../types/Round";
-import handleEndRound from "../../../handlers/round/handleEndRound";
+import type { TourneyType } from "../../../types/Tourney";
 
 const toasterErrorTitleText = 'Failed to End Round';
 
 interface StartRoundButtonProps {
   tourneyId: number;
+  tourneyType: TourneyType | null;
   round: Round | null;
   setRound: (round: Round | null) => void;
 }
 
-export default function EndRoundButton({ tourneyId, round, setRound }: StartRoundButtonProps) {
+export default function EndRoundButton({ tourneyId, tourneyType, round, setRound }: StartRoundButtonProps) {
   const [isEnding, setIsEnding] = useState(false);
   const handleEndRoundClick = async () => {
     if (!round) return;
@@ -26,7 +28,7 @@ export default function EndRoundButton({ tourneyId, round, setRound }: StartRoun
 
     try {
       setIsEnding(true);
-      const { updatedRound } = await handleEndRound({ tourneyId, round });
+      const { updatedRound } = await handleEndRound({ tourneyId, round, tourneyType });
       setRound({ ...updatedRound[0] });
       toaster.create({
         title: "Round Ended",

--- a/src/components/round/details/RoundDetails.tsx
+++ b/src/components/round/details/RoundDetails.tsx
@@ -129,6 +129,7 @@ export function RoundDetails({
                 {!loadingTourneyAdminStatus && isTourneyAdmin && round?.status === "In Progress" && (
                     <EndRoundButton
                       tourneyId={tourneyId}
+                      tourneyType={tourneyType}
                       round={round}
                       setRound={setRound}
                     />

--- a/src/handlers/round/handleAddPlayersToRound.ts
+++ b/src/handlers/round/handleAddPlayersToRound.ts
@@ -1,6 +1,6 @@
 import { supabaseClient } from "../../lib/supabaseClient";
 
-export async function handleAddPlayersToRound(roundId: number, playerTourneysIds: number[]) {
+export async function handleAddPlayersToRound(playerTourneysIds: number[], roundId: number) {
   const entries = playerTourneysIds.map(id => ({
     round_id: roundId,
     player_tourney_id: id,

--- a/src/handlers/round/handleEndRound.ts
+++ b/src/handlers/round/handleEndRound.ts
@@ -3,6 +3,7 @@ import handleUpdateRoundStatus from './handleUpdateRoundStatus';
 import calculatePlayerRankingsInRound from '../../helpers/calculatePlayerRankingsInRound';
 import {handleAddPlayersToRound} from './handleAddPlayersToRound';
 import { handleUpdateTourneyStatus } from '../handleUpdateTourneyStatus';
+import { handleUpdateRoundName } from './handleUpdateRoundName';
 import { getRoundsInTourney } from '../../helpers/getRoundsInTourney';
 import getStagesInRound from '../../helpers/getstagesInRound';
 import getPlayersInRound from '../../helpers/getPlayersInRound';
@@ -10,24 +11,23 @@ import getPlayersInRound from '../../helpers/getPlayersInRound';
 import type { PlayerRound } from '../../types/PlayerRound';
 import type { Round } from '../../types/Round';
 import type { Stage } from '../../types/Stage';
+import type { TourneyType } from '../../types/Tourney';
 
 interface handleStartRoundProps {
   tourneyId: number;
   round: Round;
+  tourneyType: TourneyType | null;
 }
 
-function determineNextRoundId(roundId: number, rounds: Round[]) {
-  const currentIndex = rounds.findIndex(r => r.id === roundId);
-  const nextRound = rounds[currentIndex + 1];
-  const nextRoundId = nextRound?.id ?? null;
-  return nextRoundId;
+function getRoundFromId(roundId: number, rounds: Round[]): Round | undefined {
+  return rounds.find(r => r.id === roundId);
 }
 
 function determineChildRounds(roundId: number, rounds: Round[]): Round[] {
   return rounds.filter(r => r.parent_round_id === roundId);
 }
 
-export default async function handleEndRound({ tourneyId, round }: handleStartRoundProps) {  
+export default async function handleEndRound({ tourneyId, round, tourneyType }: handleStartRoundProps) {  
   if (!round?.id) throw new Error('Round ID is required!');
   const stages = await getStagesInRound(round.id);
   if (!stages) throw new Error('No stages were played!');
@@ -46,10 +46,10 @@ export default async function handleEndRound({ tourneyId, round }: handleStartRo
     }
 
     // find next round ID (if there is one)
-    const nextRoundId = round.next_round_id ?? determineNextRoundId(round.id, rounds);
+    const nextRoundId = round.next_round_id ?? null;
     if (nextRoundId) {
       const advandingPlayerTourneysIds = getPlayerTourneysIds({round, players, stages, advancing: true});
-      handleAddPlayersToRound(nextRoundId, advandingPlayerTourneysIds);
+      await handleAddPlayersToRound(advandingPlayerTourneysIds, nextRoundId);
     }
 
     // find the first associated "redemption" round ID (if there is one)
@@ -57,15 +57,37 @@ export default async function handleEndRound({ tourneyId, round }: handleStartRo
     const upcomingRedemptionRound = round.parent_round_id === null ? childRounds[0] ?? null : null;
     if (upcomingRedemptionRound) {
       const redemptionPlayerTourneysIds = getPlayerTourneysIds({round, players, stages, advancing: false});
-      handleAddPlayersToRound(upcomingRedemptionRound.id, redemptionPlayerTourneysIds);
+      await handleAddPlayersToRound(redemptionPlayerTourneysIds, upcomingRedemptionRound.id);
+    }
+
+    // find the next loser round ID (if there is one)
+    const upcomingLoserRoundId = round.lost_next_round_id;
+    if (upcomingLoserRoundId) {
+      const loserPlayerTourneysIds = getPlayerTourneysIds({round, players, stages, advancing: false});
+      await handleAddPlayersToRound(loserPlayerTourneysIds, upcomingLoserRoundId);
+    }
+
+    // if tournament type is double elimination, rename the next winner and loser round (if there is one) 
+    // to include player names
+    if (tourneyType === "Double Elimination") {
+      if (nextRoundId) {
+        const nextRoundPlayers = await getPlayersInRound(nextRoundId);
+        const nextRound = getRoundFromId(nextRoundId, rounds);
+        renameRoundWithPlayerNames(nextRound, nextRoundPlayers);
+      }
+      if (upcomingLoserRoundId) {
+        const upcomingLoserRoundPlayers = await getPlayersInRound(upcomingLoserRoundId);
+        const existingRound = getRoundFromId(upcomingLoserRoundId, rounds);
+        renameRoundWithPlayerNames(existingRound, upcomingLoserRoundPlayers);
+      }
     }
 
     const updatedRound = await handleUpdateRoundStatus(round.id, 'Complete');
-
-    if (!nextRoundId) {
-      // all rounds are now complete!
+    rounds[rounds.findIndex(r => r.id === updatedRound[0].id)] = updatedRound[0];
+    if (rounds.every(round => round.status === 'Complete')) {
       handleUpdateTourneyStatus(tourneyId, 'Complete');
     }
+
     return { updatedRound };
   } catch (error) {
     console.error('Failed to end round:', error);
@@ -78,6 +100,22 @@ interface GetPlayerTourneysOptions {
   players: PlayerRound[];
   stages: Stage[];
   advancing?: boolean; // true = advancing players, false = non-advancing players
+}
+
+function renameRoundWithPlayerNames(round: Round | undefined, players: PlayerRound[] | null) {
+  if (!round || !players || players.length === 0) return;
+  const existingName = round.name;
+  const separator = ": ";
+  let updatedName = existingName.split(separator)[0] + separator;
+
+  if (players.length === 1) {
+    const playerName = players[0].player_tourneys.player_name;
+    updatedName += playerName + " vs. ??";
+  } else {
+    const playerNames = players.map(p => p.player_tourneys.player_name).join(" vs. ");
+    updatedName += playerNames;
+  }
+  handleUpdateRoundName(round.id, updatedName);
 }
 
 function getPlayerTourneysIds({

--- a/src/handlers/round/handleUpdateRoundName.ts
+++ b/src/handlers/round/handleUpdateRoundName.ts
@@ -1,0 +1,15 @@
+import { updateSupabaseTable } from '../../helpers/updateSupabaseTable';
+import type { Round } from '../../types/Round';
+
+export async function handleUpdateRoundName(roundId: number, newName: string) {
+  if (!roundId) throw new Error("Round ID is required");
+  if (!newName) throw new Error("New name is required");
+
+  const updated = await updateSupabaseTable<Round>(
+    'rounds',
+    { name: newName },
+    [{ column: 'id', value: roundId }]
+  );
+
+  return updated[0];
+}


### PR DESCRIPTION
for double elim, though technically could be expanded to replace existing (hackyish) logic for redemption waterfall tourneys also, if the tourney setup is changed to be done to use this new rounds column.